### PR TITLE
Made headers configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,12 +13,7 @@ type (
 		scheme  string
 		host    string
 		base    string
-		headers headers
-	}
-
-	headers struct {
-		scheme string
-		host   string
+		headers Headers
 	}
 )
 
@@ -27,10 +22,7 @@ func newLocation(config Config) *location {
 		scheme: config.Scheme,
 		host:   config.Host,
 		base:   config.Base,
-		headers: headers{
-			scheme: "X-Forwarded-Proto",
-			host:   "X-Forwarded-For",
-		},
+		headers: config.Headers,
 	}
 }
 
@@ -44,7 +36,7 @@ func (l *location) applyToContext(c *gin.Context) {
 
 func (l *location) resolveScheme(r *http.Request) string {
 	switch {
-	case r.Header.Get(l.headers.scheme) == "https":
+	case r.Header.Get(l.headers.Scheme) == "https":
 		return "https"
 	case r.URL.Scheme == "https":
 		return "https"
@@ -59,8 +51,8 @@ func (l *location) resolveScheme(r *http.Request) string {
 
 func (l *location) resolveHost(r *http.Request) (host string) {
 	switch {
-	case r.Header.Get(l.headers.host) != "":
-		return r.Header.Get(l.headers.host)
+	case r.Header.Get(l.headers.Host) != "":
+		return r.Header.Get(l.headers.Host)
 	case r.Header.Get("X-Host") != "":
 		return r.Header.Get("X-Host")
 	case r.Host != "":

--- a/location.go
+++ b/location.go
@@ -8,6 +8,11 @@ import (
 
 const key = "location"
 
+type Headers struct {
+	Scheme string
+	Host   string
+}
+
 // Config represents all available options for the middleware.
 type Config struct {
 	// Scheme is the default scheme that should be used when it cannot otherwise
@@ -21,6 +26,10 @@ type Config struct {
 	// Base is the base path that should be used in conjunction with proxy
 	// servers that do path re-writing.
 	Base string
+
+	// Header used to map schemes and host.
+	// May be overriden to allow reading values from custom header fields.
+	Headers Headers
 }
 
 // DefaultConfig returns a generic default configuration mapped to localhost.
@@ -28,6 +37,10 @@ func DefaultConfig() Config {
 	return Config{
 		Host:   "localhost:8080",
 		Scheme: "http",
+		Headers: Headers {
+			Scheme: "X-Forwarded-Proto",
+			Host:   "X-Forwarded-For",
+		},
 	}
 }
 


### PR DESCRIPTION
This adds support for custom header fields to read the Host and Scheme from. We need this to be able to adjust the header values to our custom proxy infrastructure and thought others might benefit from the change.