### PR TITLE
Use X-Forwared-Host for resolving host

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ func newLocation(config Config) *location {
 		base:   config.Base,
 		headers: headers{
 			scheme: "X-Forwarded-Proto",
-			host:   "X-Forwarded-For",
+			host:   "X-Forwarded-Host",
 		},
 	}
 }


### PR DESCRIPTION
X-Forwarded-For is normally used for getting the original client IP, whereas X-Forwarded-Host is normally used to get the original host requested by the client.

X-Forwarded-For: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
X-Forwarded-Host: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host