### PR TITLE
ci(actions): update Go test matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.25, 1.26]
+        go: [1.26, 1.27]
         include:
           - os: ubuntu-latest
             go-build: ~/.cache/go-build


### PR DESCRIPTION
## Summary

Update the Go test matrix to cover Go 1.26 and Go 1.27. All referenced GitHub Actions were checked against their latest available release or tag and are already current.

## Related issues

- Jira: N/A
- GitHub: N/A

## AI authorship

- [ ] No AI was used
- [x] AI was used
  - **Tool / model**: Codex (GPT-5)
  - **AI-authored files**: `.github/workflows/go.yml`
  - **Human line-by-line reviewed**: None — not yet reviewed by a human.

## Change classification

- [x] Leaf change
- [ ] Core change

## Plan reference

Update GitHub Actions configuration and limit the Go matrix to Go 1.26 and Go 1.27.

## Verification

- **Automated**: Workflow YAML parsing, `git diff --check`, and `go test ./...` passed locally with Go 1.26.2.
- **Manual**: Confirmed the matrix contains only Go 1.26 and Go 1.27; checked every referenced Action against its latest GitHub release or tag.
- **Not run**: Go 1.27 tests locally; delegated to the updated GitHub Actions matrix.

## Security check

- [x] N/A - no external or security-sensitive interface changed

## Risk and rollback

- **Risk**: CI may expose compatibility issues under Go 1.27.
- **Rollback**: Revert this commit to restore the previous matrix.

## Reviewer guide

- **Read carefully**: The Go versions in the workflow matrix.
- **Spot-check**: GitHub Actions runs for both matrix entries.
